### PR TITLE
Setup Release Pipeline

### DIFF
--- a/.github/helpers/releases.sh
+++ b/.github/helpers/releases.sh
@@ -4,11 +4,11 @@ function get_release_id() {
     i=0
     while [ $i -lt 3 ]
     do
+        i=`expr $i + 1`
         RELEASE_ID=$(curl -s -H "Authorization: token $1" \
             https://api.github.com/repos/$2/releases | \
             jq ".[] | select(.tag_name == \"$3\") | .id")
         if [ -z "$RELEASE_ID" ]; then
-            i=`expr $i + 1`
             sleep 5
         else
             echo $RELEASE_ID

--- a/.github/helpers/releases.sh
+++ b/.github/helpers/releases.sh
@@ -12,6 +12,7 @@ function get_release_id() {
             sleep 5
         else
             echo $RELEASE_ID
+            return 0
         fi
     done
     return 1

--- a/.github/helpers/releases.sh
+++ b/.github/helpers/releases.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+function get_release_id() {
+    i=0
+    while [ $i -lt 3 ]
+    do
+        RELEASE_ID=$(curl -s -H "Authorization: token $1" \
+            https://api.github.com/repos/$2/releases | \
+            jq ".[] | select(.tag_name == \"$3\") | .id")
+        if [ -z "$RELEASE_ID" ]; then
+            i=`expr $i + 1`
+            sleep 5
+        else
+            echo $RELEASE_ID
+        fi
+    done
+    return 1
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
 
     outputs:
       tag_name: ${{ steps.release.outputs.tag_name }}
-      release_id: ${{ steps.post-release.outputs.release_id }}
+      release_id: ${{ steps.release.outputs.release_id }}
 
   release-windows-bundle:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,42 +16,23 @@ jobs:
   create-release-draft:
     runs-on: ubuntu-latest
     steps:
-      - name: Check tag
-        id: prep
-        run: |
-          TAG_NAME=$(curl -s -H "Authorization: token ${{ github.token }}" \
-                      https://api.github.com/repos/${{ github.repository }}/releases | \
-                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name | select (. != null)")
-          IS_DRAFT=$(curl -s -H "Authorization: token ${{ github.token }}" \
-                      https://api.github.com/repos/${{ github.repository }}/releases | \
-                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .draft | select (. != null)")
-
-          if [ -n "${TAG_NAME}" ] && [ "${IS_DRAFT}" == "false" ];then
-              echo "A release has already been published for this run_id (${{ github.run_id }} / ${TAG_NAME})."
-              exit 1
-          fi
-          echo ::set-output name=tag_name::${TAG_NAME}
-
       - uses: actions/checkout@v3
-        if: ${{ steps.prep.outputs.tag_name == '' }}
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Setup Node version
-        if: ${{ steps.prep.outputs.tag_name == '' }}
         uses: actions/setup-node@v3
         with:
           node: '16'
 
       - name: Setup Git
-        if: ${{ steps.prep.outputs.tag_name == '' }}
         run: |
           git config --global user.name "devx-sauce-bot"
           git config --global user.email "devx.bot@saucelabs.com"
 
       - name: generate (pre-)release draft
-        if: ${{ steps.prep.outputs.tag_name == '' }}
+        id: release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -68,86 +49,47 @@ jobs:
 
           npx release-it ${{ github.event.inputs.releaseType }} ${PRE_RELEASE_ARGS}
 
-          RELEASE_NAME=$(cat version.txt)
+          TAG_NAME=$(cat version.txt)
 
-          echo ::set-output name=release_name::${RELEASE_NAME}
-          echo ::set-output name=release_name_dbg::meow
+          echo ::set-output name=tag_name::${TAG_NAME}
 
-      - run: echo "Release Name is Set!"
-        if: ${{ steps.prep.outputs.release_name != '' }}
+          RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
+            https://api.github.com/repos/${{ github.repository }}/releases | \
+            jq ".[] | select(.tag_name == \"${TAG_NAME}\") | .id"
+
+          echo ::set-output name=release_id::${RELEASE_ID}
+
+    outputs:
+      tag_name: ${{ steps.release.tag_name }}
+      release_id: ${{ steps.release.release_id }}
 
   release-windows-bundle:
     runs-on: windows-latest
     needs: [create-release-draft]
     steps:
-      - name: Find matching draft tag
-        id: prep
-        run: |
-          $res = Invoke-WebRequest -Uri "https://api.github.com/repos/${{ github.repository }}/releases" -Headers @{'Authorization' = "token ${{ github.token }}"}
-          $jsonObj = ConvertFrom-Json $([String]::new($res.Content))
-
-          $selectedRelease = $null
-          Foreach ($release in $jsonObj)
-          {
-              if ( ! $release.body -contains "- jobId: ${{ github.run_id }}}\\n") {
-                  continue
-              }
-              if ( ! $release.draft ) {
-                  continue
-              }
-              $selectedRelease = $release
-              break
-          }
-
-          if ( $null -eq $selectedRelease ) {
-              exit 1
-          }
-
-          $selectedAsset = $null
-          Foreach ($asset in $selectedRelease.assets) {
-            if ($asset.name -eq "puppeteer-replay-runner-win.zip") {
-              $selectedAsset = $asset
-            }
-          }
-
-          $tagName = $selectedRelease.tag_name
-          $releaseId = $selectedRelease.id
-          $assetId = $selectedAsset.id
-          Write-Output "::set-output name=version::$tagName"
-          Write-Output "::set-output name=release_id::$releaseId"
-          Write-Output "::set-output name=asset_id::$assetId"
-
-      - run: Write-Output "${{ steps.prep.outputs.release_id }} - ${{ steps.prep.outputs.version }} - ${{ steps.prep.outputs.asset_id }}"
-
       - uses: actions/checkout@v3
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         with:
-          ref: ${{ steps.prep.outputs.version }}
+          ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - name: Setup node version
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/setup-node@v3
         with:
           node: '16'
 
       - name: Update Release version
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: |
-          npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
+          npm version --no-git-tag-version ${{ needs.create-release-draft.outputs.tag_name }}
 
       - run: npm ci
-        if: ${{ steps.prep.outputs.asset_id == '' }}
 
       - name: Create Bundle
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: npm run bundle
 
       - name: List bundle contents
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: ls -R bundle/
 
       - name: Archive bundle
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: azure/powershell@v1
         with:
           inlineScript: |
@@ -155,13 +97,12 @@ jobs:
           azPSVersion: '3.1.0'
 
       - name: Upload Release Asset
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=puppeteer-replay-runner-win.zip
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-release-draft.outputs.release_id }}/assets?name=puppeteer-replay-runner-win.zip
           asset_path: ./puppeteer-replay-runner-win.zip
           asset_name: puppeteer-replay-runner-win.zip
           asset_content_type: application/zip
@@ -170,93 +111,48 @@ jobs:
     runs-on: macos-latest
     needs: [create-release-draft]
     steps:
-      - name: Find matching draft tag
-        id: prep
-        run: |
-          VERSION=$(curl -s -H "Authorization: token ${{ github.token }}" \
-                      https://api.github.com/repos/${{ github.repository }}/releases | \
-                      jq -r "[.[] | select(.draft == true) | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .tag_name")
-          RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
-                      https://api.github.com/repos/${{ github.repository }}/releases | \
-                      jq -r "[.[] | select(.draft == true) | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .id")
-
-          if [ "${VERSION}" = "" ];then
-              echo "No draft version found"
-              exit 1
-          fi
-
-          ASSET_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
-                      https://api.github.com/repos/${{ github.repository }}/releases | \
-                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .assets | .[] | select(.name == \"puppeteer-replay-runner-macos.zip\") | .id | select(. != null)")
-
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=release_id::${RELEASE_ID}
-          echo ::set-output name=asset_id::${ASSET_ID}
-
-      - run: echo "${{ steps.prep.outputs.release_id }} - ${{ steps.prep.outputs.version }} - ${{ steps.prep.outputs.asset_id }}"
-
       - uses: actions/checkout@v3
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         with:
-          ref: ${{ steps.prep.outputs.version }}
+          ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - name: Setup Node
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         uses: actions/setup-node@v3
         with:
           node: '16'
 
       - name: Update Release version
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: |
-          npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
+          npm version --no-git-tag-version ${{ needs.create-release-draft.outputs.tag_name }}
 
       - run: npm ci
-        if: ${{ steps.prep.outputs.asset_id == '' }}
 
       - name: Create Bundle
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: npm run bundle
 
       - name: List bundle contents
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: ls -R bundle/
 
       - name: Archive bundle
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         run: zip --symlinks -r puppeteer-replay-runner-macos.zip bundle/
 
       - name: Upload Release Asset
-        if: ${{ steps.prep.outputs.asset_id == '' }}
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }}/assets?name=puppeteer-replay-runner-macos.zip
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-release-draft.outputs.release_id }}/assets?name=puppeteer-replay-runner-macos.zip
           asset_path: ./puppeteer-replay-runner-macos.zip
           asset_name: puppeteer-replay-runner-macos.zip
           asset_content_type: application/zip
 
   publish-release:
     runs-on: ubuntu-latest
-    needs: [release-windows-bundle, release-macos-bundle]
+    needs: [create-release-draft, release-windows-bundle, release-macos-bundle]
     steps:
-      - name: Find matching draft tag
-        id: prep
-        run: |
-          RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
-                      https://api.github.com/repos/${{ github.repository }}/releases | \
-                      jq -r "[.[] | select(.draft == true) | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .id")
-
-          if [ "${RELEASE_ID}" = "" ];then
-              echo "No draft version found"
-              exit 1
-          fi
-          echo ::set-output name=release_id::${RELEASE_ID}
-
       - name: Publish release
         run: |
           curl -f -X PATCH -H "Authorization: token ${{ github.token }}" \
-            https://api.github.com/repos/${{ github.repository }}/releases/${{ steps.prep.outputs.release_id }} \
+            https://api.github.com/repos/${{ github.repository }}/releases/${{ needs.create-release-draft.outputs.release_id }} \
             -d '{"draft":"false"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,9 @@ jobs:
 
           npx release-it ${{ github.event.inputs.releaseType }} ${PRE_RELEASE_ARGS}
 
-          echo ::set-output name=release_name::$(cat version.txt)
+          RELEASE_NAME=$(cat version.txt)
+
+          echo ::set-output name=release_name::${RELEASE_NAME}
 
       - run: echo "Release ${{ steps.prep.outputs.release_name }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,11 @@ jobs:
 
           RELEASE_NAME=$(cat version.txt)
 
-          echo "::set-output name=release_name::${RELEASE_NAME}"
-          echo "::set-output name=release_name_dbg::meow"
+          echo ::set-output name=release_name::${RELEASE_NAME}
+          echo ::set-output name=release_name_dbg::meow
 
-      - run: ls -lah
-      - run: echo "Release ${{ steps.prep.outputs.release_name }} - ${{ steps.prep.outputs.release_name_dbg }}"
+      - run: echo "Release Name is Set!"
+        if: ${{ steps.prep.outputs.release_name != '' }}
 
   release-windows-bundle:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
           RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
             https://api.github.com/repos/${{ github.repository }}/releases | \
-            jq ".[] | select(.tag_name == \"${TAG_NAME}\") | .id"
+            jq ".[] | select(.tag_name == \"${TAG_NAME}\") | .id")
 
           echo ::set-output name=release_id::${RELEASE_ID}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,18 @@ jobs:
     runs-on: windows-latest
     needs: [create-release-draft]
     steps:
+      - name: Verify Dependencies
+        run: |
+          if [ "${{ needs.create-release-draft.outputs.tag_name }}" = "" ];then
+              echo "Missing required tag name"
+              exit 1
+          fi
+
+          if [ "${{ needs.create-release-draft.outputs.release_id }}" = "" ];then
+              echo "Missing required release ID"
+              exit 1
+          fi
+
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
@@ -111,6 +123,18 @@ jobs:
     runs-on: macos-latest
     needs: [create-release-draft]
     steps:
+      - name: Verify Dependencies
+        run: |
+          if [ "${{ needs.create-release-draft.outputs.tag_name }}" = "" ];then
+              echo "Missing required tag name"
+              exit 1
+          fi
+
+          if [ "${{ needs.create-release-draft.outputs.release_id }}" = "" ];then
+              echo "Missing required release ID"
+              exit 1
+          fi
+
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
@@ -151,6 +175,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [create-release-draft, release-windows-bundle, release-macos-bundle]
     steps:
+      - name: Verify Dependencies
+        run: |
+          if [ "${{ needs.create-release-draft.outputs.release_id }}" = "" ];then
+              echo "Missing required release ID"
+              exit 1
+          fi
+
       - name: Publish release
         run: |
           curl -f -X PATCH -H "Authorization: token ${{ github.token }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
 
           npx release-it ${{ github.event.inputs.releaseType }} ${PRE_RELEASE_ARGS}
 
+          echo $RELEASE_NAME
+
   release-windows-bundle:
     runs-on: windows-latest
     needs: [create-release-draft]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
             exit 1          
           }
 
-          if ( $null -eq "${{ needs.create-release-draft.outputs.release_id }}" {
+          if ( $null -eq "${{ needs.create-release-draft.outputs.release_id }}" ) {
             echo "Missing required release ID"
             exit 1
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,8 @@ jobs:
           echo ::set-output name=release_id::${RELEASE_ID}
 
     outputs:
-      tag_name: ${{ steps.release.tag_name }}
-      release_id: ${{ steps.release.release_id }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_id: ${{ steps.release.outputs.release_id }}
 
   release-windows-bundle:
     runs-on: windows-latest
@@ -69,12 +69,12 @@ jobs:
     steps:
       - name: Verify Dependencies
         run: |
-          if [ "${{ needs.create-release-draft.outputs.tag_name }}" = "" ];then
+          if [ -z "${{ needs.create-release-draft.outputs.tag_name }}" ];then
               echo "Missing required tag name"
               exit 1
           fi
 
-          if [ "${{ needs.create-release-draft.outputs.release_id }}" = "" ];then
+          if [ -z "${{ needs.create-release-draft.outputs.release_id }}" ];then
               echo "Missing required release ID"
               exit 1
           fi
@@ -125,12 +125,12 @@ jobs:
     steps:
       - name: Verify Dependencies
         run: |
-          if [ "${{ needs.create-release-draft.outputs.tag_name }}" = "" ];then
+          if [ -z "${{ needs.create-release-draft.outputs.tag_name }}" ];then
               echo "Missing required tag name"
               exit 1
           fi
 
-          if [ "${{ needs.create-release-draft.outputs.release_id }}" = "" ];then
+          if [ -z "${{ needs.create-release-draft.outputs.release_id }}" ];then
               echo "Missing required release ID"
               exit 1
           fi
@@ -177,7 +177,7 @@ jobs:
     steps:
       - name: Verify Dependencies
         run: |
-          if [ "${{ needs.create-release-draft.outputs.release_id }}" = "" ];then
+          if [ -z "${{ needs.create-release-draft.outputs.release_id }}" ];then
               echo "Missing required release ID"
               exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,6 @@ jobs:
           azPSVersion: '3.1.0'
 
       - name: Upload Release Asset
-        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -129,7 +128,6 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload Release Asset Legacy
-        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -181,7 +179,6 @@ jobs:
         run: zip --symlinks -r puppeteer-replay-runner-macos.zip bundle/
 
       - name: Upload Release Asset
-        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,8 @@ jobs:
 
           RELEASE_NAME=$(cat version.txt)
 
-          echo ::set-output name=release_name::${RELEASE_NAME}
-          echo ::set-output name=release_name_dbg::meow
+          echo "::set-output name=release_name::${RELEASE_NAME}"
+          echo "::set-output name=release_name_dbg::meow"
 
       - run: ls -lah
       - run: echo "Release ${{ steps.prep.outputs.release_name }} - ${{ steps.prep.outputs.release_name_dbg }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,10 @@ jobs:
           RELEASE_NAME=$(cat version.txt)
 
           echo ::set-output name=release_name::${RELEASE_NAME}
+          echo ::set-output name=release_name_dbg::meow
 
       - run: ls -lah
-      - run: echo "Release ${{ steps.prep.outputs.release_name }}"
+      - run: echo "Release ${{ steps.prep.outputs.release_name }} - ${{ steps.prep.outputs.release_name_dbg }}"
 
   release-windows-bundle:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,9 @@ jobs:
 
           npx release-it ${{ github.event.inputs.releaseType }} ${PRE_RELEASE_ARGS}
 
-          echo $RELEASE_NAME
+          echo ::set-output name=release_name::${RELEASE_NAME}
+
+      - run: 'Generated Release ${{ steps.prep.outputs.release_name }}'
 
   release-windows-bundle:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           sleep 5
           RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
             https://api.github.com/repos/${{ github.repository }}/releases | \
-            jq ".[] | select(.tag_name == \"${{ steps.release.tag_name }}\") | .id")
+            jq ".[] | select(.tag_name == \"${{ steps.release.outputs.tag_name }}\") | .id")
 
           echo ::set-output name=release_id::${RELEASE_ID}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Post Release Capture
         id: post-release
         run: |
-          sleep 5
           RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
             https://api.github.com/repos/${{ github.repository }}/releases | \
             jq ".[] | select(.tag_name == \"${{ steps.release.outputs.tag_name }}\") | .id")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
 
-      - run: npm ci --production
+      - run: npm ci
         if: ${{ steps.prep.outputs.asset_id == '' }}
 
       - name: Create Bundle
@@ -203,7 +203,7 @@ jobs:
         run: |
           npm version --no-git-tag-version ${{  steps.prep.outputs.version }}
 
-      - run: npm ci --production
+      - run: npm ci
         if: ${{ steps.prep.outputs.asset_id == '' }}
 
       - name: Create Bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
 
           echo ::set-output name=release_name::${RELEASE_NAME}
 
-      - run: 'Generated Release ${{ steps.prep.outputs.release_name }}'
+      - run: echo "Release ${{ steps.prep.outputs.release_name }}"
 
   release-windows-bundle:
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,25 +53,20 @@ jobs:
 
           echo ::set-output name=tag_name::${TAG_NAME}
 
-          # RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
-          #   https://api.github.com/repos/${{ github.repository }}/releases | \
-          #   jq ".[] | select(.tag_name == \"${TAG_NAME}\") | .id")
+          source .github/helpers/releases.sh
 
-          # echo ::set-output name=release_id::${RELEASE_ID}
-
-      - name: Post Release Capture
-        id: post-release
-        run: |
-          RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            https://api.github.com/repos/${{ github.repository }}/releases | \
-            jq ".[] | select(.tag_name == \"${{ steps.release.outputs.tag_name }}\") | .id")
+          RELEASE_ID=$(get_release_id ${{ github.token }} ${{ github.repository }} $TAG_NAME)
+          if [ -z "$RELEASE_ID" ]; then
+            echo "Failed to get the release ID"
+            exit 1
+          fi
 
           echo ::set-output name=release_id::${RELEASE_ID}
 
       - name: Outputs
         run: |
           echo "tag_name: ${{ steps.release.outputs.tag_name }}"
-          echo "release_id: ${{ steps.post-release.outputs.release_id }}"
+          echo "release_id: ${{ steps.release.outputs.release_id }}"
 
     outputs:
       tag_name: ${{ steps.release.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,17 @@ jobs:
           asset_name: puppeteer-replay-runner-win.zip
           asset_content_type: application/zip
 
+      - name: Upload Release Asset Legacy
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-release-draft.outputs.release_id }}/assets?name=puppeteer-replay-runner.zip
+          asset_path: ./puppeteer-replay-runner-win.zip
+          asset_name: puppeteer-replay-runner.zip
+          asset_content_type: application/zip
+
   release-macos-bundle:
     runs-on: macos-latest
     needs: [create-release-draft]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
 
           ASSET_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
                       https://api.github.com/repos/${{ github.repository }}/releases | \
-                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .assets | .[] | select(.name == \"sauce-testcafe-macos.zip\") | .id | select(. != null)")
+                      jq -r "[.[] | select(.body | contains(\"- jobId: ${{ github.run_id }}\\n\"))] | first | .assets | .[] | select(.name == \"puppeteer-replay-runner-macos.zip\") | .id | select(. != null)")
 
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=release_id::${RELEASE_ID}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node version
         uses: actions/setup-node@v3
         with:
-          node: '16'
+          node-version: '16'
 
       - name: Setup Git
         run: |
@@ -96,7 +96,7 @@ jobs:
       - name: Setup node version
         uses: actions/setup-node@v3
         with:
-          node: '16'
+          node-version: '16'
 
       - name: Update Release version
         run: |
@@ -161,7 +161,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node: '16'
+          node-version: '16'
 
       - name: Update Release version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,7 @@ jobs:
 
   publish-release:
     runs-on: ubuntu-latest
-    needs: [release-docker, release-windows-bundle, release-macos-bundle]
+    needs: [release-windows-bundle, release-macos-bundle]
     steps:
       - name: Find matching draft tag
         id: prep

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Post Release Capture
         id: post-release
         run: |
+          sleep 5
           RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
             https://api.github.com/repos/${{ github.repository }}/releases | \
             jq ".[] | select(.tag_name == \"${{ steps.release.tag_name }}\") | .id")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
 
           echo ::set-output name=release_name::${RELEASE_NAME}
 
+      - run: ls -lah
       - run: echo "Release ${{ steps.prep.outputs.release_name }}"
 
   release-windows-bundle:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,20 +53,29 @@ jobs:
 
           echo ::set-output name=tag_name::${TAG_NAME}
 
+          # RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
+          #   https://api.github.com/repos/${{ github.repository }}/releases | \
+          #   jq ".[] | select(.tag_name == \"${TAG_NAME}\") | .id")
+
+          # echo ::set-output name=release_id::${RELEASE_ID}
+
+      - name: Post Release Capture
+        id: post-release
+        run: |
           RELEASE_ID=$(curl -s -H "Authorization: token ${{ github.token }}" \
             https://api.github.com/repos/${{ github.repository }}/releases | \
-            jq ".[] | select(.tag_name == \"${TAG_NAME}\") | .id")
+            jq ".[] | select(.tag_name == \"${{ steps.release.tag_name }}\") | .id")
 
           echo ::set-output name=release_id::${RELEASE_ID}
 
       - name: Outputs
         run: |
           echo "tag_name: ${{ steps.release.outputs.tag_name }}"
-          echo "release_id: ${{ steps.release.outputs.release_id }}"
+          echo "release_id: ${{ steps.post-release.outputs.release_id }}"
 
     outputs:
       tag_name: ${{ steps.release.outputs.tag_name }}
-      release_id: ${{ steps.release.outputs.release_id }}
+      release_id: ${{ steps.post-release.outputs.release_id }}
 
   release-windows-bundle:
     runs-on: windows-latest
@@ -74,12 +83,12 @@ jobs:
     steps:
       - name: Verify Dependencies
         run: |
-          if ( $null -eq ${{ needs.create-release-draft.outputs.tag_name }} ) {
+          if ( $null -eq "${{ needs.create-release-draft.outputs.tag_name }}" ) {
             echo "Missing required tag name"
             exit 1          
           }
 
-          if ( $null -eq ${{ needs.create-release-draft.outputs.release_id }} {
+          if ( $null -eq "${{ needs.create-release-draft.outputs.release_id }}" {
             echo "Missing required release ID"
             exit 1
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          if [ -z "${{ github.event.inputs.releaseType }}" ] && [ -z "${{ github.event.inputs.preReleaseFlavor }}" ];then
+          if [ -z "${{ github.event.inputs.releaseType }}" ] && [ -z "${{ github.event.inputs.preReleaseFlavor }}" ]; then
             echo "No release type provided."
             exit 1
           fi
 
-          if [ -n "${{ github.event.inputs.preReleaseFlavor }}" ];then
+          if [ -n "${{ github.event.inputs.preReleaseFlavor }}" ]; then
             PRE_RELEASE_ARGS="--preRelease=${{ github.event.inputs.preReleaseFlavor }} --github.preRelease"
           fi
 
@@ -59,6 +59,11 @@ jobs:
 
           echo ::set-output name=release_id::${RELEASE_ID}
 
+      - name: Outputs
+        run: |
+          echo "tag_name: ${{ steps.release.outputs.tag_name }}"
+          echo "release_id: ${{ steps.release.outputs.release_id }}"
+
     outputs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       release_id: ${{ steps.release.outputs.release_id }}
@@ -69,15 +74,15 @@ jobs:
     steps:
       - name: Verify Dependencies
         run: |
-          if [ -z "${{ needs.create-release-draft.outputs.tag_name }}" ];then
-              echo "Missing required tag name"
-              exit 1
-          fi
+          if ( $null -eq ${{ needs.create-release-draft.outputs.tag_name }} ) {
+            echo "Missing required tag name"
+            exit 1          
+          }
 
-          if [ -z "${{ needs.create-release-draft.outputs.release_id }}" ];then
-              echo "Missing required release ID"
-              exit 1
-          fi
+          if ( $null -eq ${{ needs.create-release-draft.outputs.release_id }} {
+            echo "Missing required release ID"
+            exit 1
+          }
 
       - uses: actions/checkout@v3
         with:
@@ -125,12 +130,12 @@ jobs:
     steps:
       - name: Verify Dependencies
         run: |
-          if [ -z "${{ needs.create-release-draft.outputs.tag_name }}" ];then
+          if [ -z "${{ needs.create-release-draft.outputs.tag_name }}" ]; then
               echo "Missing required tag name"
               exit 1
           fi
 
-          if [ -z "${{ needs.create-release-draft.outputs.release_id }}" ];then
+          if [ -z "${{ needs.create-release-draft.outputs.release_id }}" ]; then
               echo "Missing required release ID"
               exit 1
           fi
@@ -177,7 +182,7 @@ jobs:
     steps:
       - name: Verify Dependencies
         run: |
-          if [ -z "${{ needs.create-release-draft.outputs.release_id }}" ];then
+          if [ -z "${{ needs.create-release-draft.outputs.release_id }}" ]; then
               echo "Missing required release ID"
               exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
 
           npx release-it ${{ github.event.inputs.releaseType }} ${PRE_RELEASE_ARGS}
 
-          echo ::set-output name=release_name::${RELEASE_NAME}
+          echo ::set-output name=release_name::$(cat version.txt)
 
       - run: echo "Release ${{ steps.prep.outputs.release_name }}"
 

--- a/.release-it.json
+++ b/.release-it.json
@@ -12,5 +12,8 @@
         "release": true,
         "draft": true,
         "releaseName": "v${version}"
+    },
+    "hooks": {
+        "after:release": "export RELEASE_NAME=v${version}"
     }
 }

--- a/.release-it.json
+++ b/.release-it.json
@@ -14,6 +14,6 @@
         "releaseName": "v${version}"
     },
     "hooks": {
-        "after:release": "export RELEASE_NAME=v${version}"
+        "after:release": "echo v${version} > version.txt"
     }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "prebundle": "npm run build",
-    "bundle": "scripts/bundle.sh",
+    "bundle": "bash scripts/bundle.sh",
     "release": "release-it --github.release",
     "release:ci": "npm run release -- --ci --npm.skipChecks --no-git.requireCleanWorkingDir",
     "release:patch": "npm run release -- patch",

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -3,8 +3,12 @@ rm -rf ./bundle/
 set -e
 mkdir ./bundle/
 cp -r ./lib/ ./bundle/lib/
-cp -r node_modules/ ./bundle/node_modules/
 cp package.json bundle/package.json
 cp package-lock.json bundle/package-lock.json
 cp "$(which node)" bundle/
-rm -r bundle/node_modules/puppeteer/.local-chromium
+
+pushd bundle/
+npm cache clean --force
+npm ci --production
+rm -r node_modules/puppeteer/.local-chromium
+popd


### PR DESCRIPTION
Add release pipeline.

In contrast to the other runners we have, I tried to simplify the workflow slightly by moving all the release logic (tag name, release IDs etc.) into a single job.

A poll/fetch for the release ID retrieval still had to be included, because:
- release ID is required for attaching assets
- the `release-it` tool doesn't make this info available
- the release creation is actually async, or at the very least, github needs a few seconds before a query of the releases API shows the new release, hence the polling.