### PR TITLE
bump deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@puppeteer/replay": "1.1.1",
-        "puppeteer": "17.0.0",
+        "@puppeteer/replay": "1.3.1",
+        "puppeteer": "19.0.0",
         "yargs": "^17.4.0"
       },
       "devDependencies": {
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@puppeteer/replay": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/replay/-/replay-1.1.1.tgz",
-      "integrity": "sha512-PS8jJgfx1jwi9bnI1L+Rt1U2g3zSsuNJWbUu6hrz1ophDK+lUBTxxU5JtUUE7lIxHbJR9GBGuGplZRwUNdG5Xw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/replay/-/replay-1.3.1.tgz",
+      "integrity": "sha512-XDufbSzKBoC8KWl22ZuCY9kLmUoLlGz3RcQB6OkOEguqiSnJ6Yb2dnMOYanNuufsNpGVbUdNd0ZEuCM2mO1HvQ==",
       "dependencies": {
         "cli-table3": "0.6.2",
         "colorette": "2.0.19",
@@ -373,7 +373,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "puppeteer": ">=16.2.0"
+        "puppeteer": ">=18.0.5"
       },
       "peerDependenciesMeta": {
         "puppeteer": {
@@ -1355,9 +1355,9 @@
       "dev": true
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1019158",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1019158.tgz",
-      "integrity": "sha512-wvq+KscQ7/6spEV7czhnZc9RM/woz1AY+/Vpd8/h2HFMwJSdTliu7f/yr1A6vDdJfKICZsShqsYpEQbdhg8AFQ=="
+      "version": "0.0.1045489",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1045489.tgz",
+      "integrity": "sha512-D+PTmWulkuQW4D1NTiCRCFxF7pQPn0hgp4YyX4wAQ6xYXKOadSWPR3ENGDQ47MW/Ewc9v2rpC/UEEGahgBYpSQ=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -3981,22 +3981,35 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.0.0.tgz",
-      "integrity": "sha512-T2rdzlPxnPezF218kywFP3O+0YI5/8Kl8riNUicGb+KuMyDTrqRjhSOSDp6coQ1T4QYPBARTFp4EMBepMOzAQA==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.0.0.tgz",
+      "integrity": "sha512-3Ga5IVerQQ2hKU9q7T28RmcUsd8F2kL6cYuPcPCzeclSjmHhGydPBZL/KJKC02sG6J6Wfry85uiWpbkjQ5qBiw==",
       "hasInstallScript": true,
+      "dependencies": {
+        "https-proxy-agent": "5.0.1",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "puppeteer-core": "19.0.0"
+      },
+      "engines": {
+        "node": ">=14.1.0"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.0.0.tgz",
+      "integrity": "sha512-OljQ9W5M4cBX68vnOAGbcRkVENDHn6lfj6QYoGsnLQsxPAh6ExTQAhHauwdFdQkhYdDExZFWlKArnBONzeHY+g==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1019158",
+        "devtools-protocol": "0.0.1045489",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.8.1"
+        "ws": "8.9.0"
       },
       "engines": {
         "node": ">=14.1.0"
@@ -5081,9 +5094,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5449,9 +5462,9 @@
       }
     },
     "@puppeteer/replay": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/replay/-/replay-1.1.1.tgz",
-      "integrity": "sha512-PS8jJgfx1jwi9bnI1L+Rt1U2g3zSsuNJWbUu6hrz1ophDK+lUBTxxU5JtUUE7lIxHbJR9GBGuGplZRwUNdG5Xw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/replay/-/replay-1.3.1.tgz",
+      "integrity": "sha512-XDufbSzKBoC8KWl22ZuCY9kLmUoLlGz3RcQB6OkOEguqiSnJ6Yb2dnMOYanNuufsNpGVbUdNd0ZEuCM2mO1HvQ==",
       "requires": {
         "cli-table3": "0.6.2",
         "colorette": "2.0.19",
@@ -6144,9 +6157,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1019158",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1019158.tgz",
-      "integrity": "sha512-wvq+KscQ7/6spEV7czhnZc9RM/woz1AY+/Vpd8/h2HFMwJSdTliu7f/yr1A6vDdJfKICZsShqsYpEQbdhg8AFQ=="
+      "version": "0.0.1045489",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1045489.tgz",
+      "integrity": "sha512-D+PTmWulkuQW4D1NTiCRCFxF7pQPn0hgp4YyX4wAQ6xYXKOadSWPR3ENGDQ47MW/Ewc9v2rpC/UEEGahgBYpSQ=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -8085,21 +8098,31 @@
       }
     },
     "puppeteer": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-17.0.0.tgz",
-      "integrity": "sha512-T2rdzlPxnPezF218kywFP3O+0YI5/8Kl8riNUicGb+KuMyDTrqRjhSOSDp6coQ1T4QYPBARTFp4EMBepMOzAQA==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-19.0.0.tgz",
+      "integrity": "sha512-3Ga5IVerQQ2hKU9q7T28RmcUsd8F2kL6cYuPcPCzeclSjmHhGydPBZL/KJKC02sG6J6Wfry85uiWpbkjQ5qBiw==",
+      "requires": {
+        "https-proxy-agent": "5.0.1",
+        "progress": "2.0.3",
+        "proxy-from-env": "1.1.0",
+        "puppeteer-core": "19.0.0"
+      }
+    },
+    "puppeteer-core": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.0.0.tgz",
+      "integrity": "sha512-OljQ9W5M4cBX68vnOAGbcRkVENDHn6lfj6QYoGsnLQsxPAh6ExTQAhHauwdFdQkhYdDExZFWlKArnBONzeHY+g==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1019158",
+        "devtools-protocol": "0.0.1045489",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
-        "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.8.1"
+        "ws": "8.9.0"
       }
     },
     "qs": {
@@ -8903,9 +8926,9 @@
       }
     },
     "ws": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.1.tgz",
-      "integrity": "sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.9.0.tgz",
+      "integrity": "sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==",
       "requires": {}
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@puppeteer/replay": "1.1.1",
-    "puppeteer": "17.0.0",
+    "@puppeteer/replay": "1.3.1",
+    "puppeteer": "19.0.0",
     "yargs": "^17.4.0"
   },
   "devDependencies": {

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -10,5 +10,4 @@ cp "$(which node)" bundle/
 pushd bundle/
 npm cache clean --force
 npm ci --production
-rm -r node_modules/puppeteer/.local-chromium
 popd


### PR DESCRIPTION
Bump framework

fyi, puppeteer@19 no longer downloads browsers to `.local-chromium`. They go to `~/.cache/puppeteer`. In case y'all are wondering about the change to the bundle script (https://github.com/puppeteer/puppeteer/pull/9095)