### PR TITLE
ci: update gcloud actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,12 +47,12 @@ jobs:
           python-version: '3.11'
 
       - name: Google Cloud Login
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.GCS_RUNNER_SA_KEY }}'
 
       - name: Install gcloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCS_RUNNER_PROJECT_ID }}
         env:
@@ -117,12 +117,12 @@ jobs:
           python-version: '3.11'
 
       - name: Google Cloud Login
-        uses: 'google-github-actions/auth@v0'
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: '${{ secrets.GCS_RUNNER_SA_KEY }}'
 
       - name: Install gcloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.GCS_RUNNER_PROJECT_ID }}
         env:


### PR DESCRIPTION
## Description

`v0` is no longer supported.

![Screenshot 2024-01-18 at 12 30 16 PM](https://github.com/saucelabs/puppeteer-replay-runner/assets/1869292/916d6a41-84c7-4381-aa99-b6bd7167f0cc)
