### PR TITLE
fix: add @eslint/js as explicit devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "yargs": "^18.0.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.0",
         "@tsconfig/node22": "^22.0.5",
         "@types/eslint-config-prettier": "^6.11.3",
         "@types/node": "^25.3.3",
@@ -204,6 +205,19 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/eslint-config-prettier": "^6.11.3",
     "@types/node": "^25.3.3",
     "@types/yargs": "^17.0.35",
+    "@eslint/js": "^9.39.0",
     "eslint": "^10.0.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",


### PR DESCRIPTION
…lity

## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
- ESLint 10 (bumped in #83) no longer bundles `@eslint/js` internally
- CI lint step fails with `ERR_MODULE_NOT_FOUND: Cannot find package '@eslint/js'`
- Added `@eslint/js@^9.39.0` as an explicit devDependency to fix the import in `eslint.config.mjs`