### PR TITLE
fix: set explicit rootDir and types in tsconfig.json for TS 6.x

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
   "include": ["src/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
+    "rootDir": "./src" /* Specify the root folder within your source files. */,
     "outDir": "./lib" /* Specify an output folder for all emitted files. */,
+    "types": ["node"] /* Specify type package names to be included without being referenced in a source file. */,
     "strict": false /* Enable all strict type-checking options. */
   }
 }


### PR DESCRIPTION
## Description
<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature
request, be sure to link to that issue.
-->
TypeScript 6.0 promotes the previously-inferred common source directory into a hard error (TS5011) when outDir is set without an explicit rootDir. Spell out rootDir: ./src and narrow types to ["node"] so the build keeps working under both TS 5.9 (current) and TS 6.x (incoming via monthly dependency update). Mirrors the equivalent change in sauce-cypress-runner #353.
