### PR TITLE
chore: drop the placeholder test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "scripts": {
     "lint": "prettier --check '**/*.{js,ts,mjs,cjs}' && eslint src/**",
     "fmt": "prettier --write '**/*.{js,ts,mjs,cjs}'",
-    "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
     "watch": "tsc -w",
     "prebundle": "npm run build",


### PR DESCRIPTION
## What

Remove the default `"test": "echo \"Error: no test specified\" && exit 1"` script from `package.json`.

## Why

The dependency update workflow gates its test phase on `HAS_TEST=$(npm pkg get scripts.test | grep -cv '^{}$')`, which only skips when the script is absent. The placeholder counts as present, so `npm test` runs, exits 1, and every dependency PR gets titled `⚠️ [TESTS FAILING]` regardless of the change — see #94, where all 5 CI checks pass.

With the key removed the guard reads `{}` and skips the phase as intended. Nothing else references `npm test`; the Test workflow runs lint, both builds and the bundle tests.